### PR TITLE
Updated orthofinder to 1.1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN orthofinder.py -f ${ORTHOFINDER_PATH}/ExampleDataset/
 
 ########################## clean source file #################################
 
-RUN rm -r /opt/0.7.1.zip
+RUN rm -r /opt/1.1.4.zip
 
 ###############################################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Set the base image to debian blast
 FROM simonalpha/ncbi-blast-docker
 
-LABEL version="0.7.1"
+LABEL version="1.1.4"
 
 # Set noninterative mode
 ENV DEBIAN_FRONTEND noninteractive
@@ -17,9 +17,9 @@ ENV FASTTREE_URL http://www.microbesonline.org/fasttree/FastTree
 ENV MCL_URL http://micans.org/mcl/src/mcl-14-137.tar.gz
 ENV MCL_PATH /opt/mcl-14-137
 
-ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/archive/0.7.1.zip
-ENV ORTHOFINDER_FILE_NAME 0.7.1.zip
-ENV ORTHOFINDER_PATH /opt/OrthoFinder-0.7.1
+ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/archive/1.1.4.zip
+ENV ORTHOFINDER_FILE_NAME 1.1.4.zip
+ENV ORTHOFINDER_PATH /opt/OrthoFinder-1.1.4
 
 ################## Update & upgrade ######################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,32 +10,25 @@ LABEL version="1.1.4"
 
 # Set noninterative mode
 ENV DEBIAN_FRONTEND noninteractive
-ENV PACKAGES wget make gcc g++ mafft unzip python-pip python-dev libatlas-base-dev gfortran
-
-ENV FASTTREE_URL http://www.microbesonline.org/fasttree/FastTree
-
-ENV MCL_URL http://micans.org/mcl/src/mcl-14-137.tar.gz
-ENV MCL_PATH /opt/mcl-14-137
-
-ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/archive/1.1.4.zip
-ENV ORTHOFINDER_FILE_NAME 1.1.4.zip
-ENV ORTHOFINDER_PATH /opt/OrthoFinder-1.1.4
 
 ################## Update & upgrade ######################
+ENV PACKAGES wget make gcc g++ mafft unzip python-pip python-dev libatlas-base-dev gfortran
 
 RUN apt-get update -y
 RUN apt-get install -y ${PACKAGES}
 
 ################# Numpy / Scipy install ########################
-
 RUN pip install numpy
 RUN pip install scipy
 
 ################# Fastree install ########################
+ENV FASTTREE_URL http://www.microbesonline.org/fasttree/FastTree
 
 RUN wget -P /usr/local/bin ${FASTTREE_URL}
 
 ################# MCL install ########################
+ENV MCL_URL http://micans.org/mcl/src/mcl-14-137.tar.gz
+ENV MCL_PATH /opt/mcl-14-137
 
 WORKDIR /opt
 RUN wget ${MCL_URL} -O - | tar xvzf -
@@ -43,14 +36,37 @@ WORKDIR ${MCL_PATH}
 
 RUN ./configure --prefix=/usr/local && make install
 
+################# DLCpar install ########################
+ENV DLCPAR_URL https://www.cs.hmc.edu/~yjw/software/dlcpar/pub/sw/dlcpar-1.0.tar.gz
+ENV DLCPAR_PATH /opt/dlcpar-1.0
+
+WORKDIR /opt
+RUN wget ${DLCPAR_URL} --no-check-certificate -O - | tar zxvf -
+WORKDIR ${DLCPAR_PATH}
+
+RUN python setup.py install
+
+################ FastME install ##########################
+ENV FASTME_URL http://www.atgc-montpellier.fr/download/sources/fastme/fastme-2.1.5.tar.gz
+ENV FASTME_PATH fastme-2.1.5
+
+WORKDIR /opt
+RUN wget ${FASTME_URL} --no-check-certificate -O - | tar zxvf -
+WORKDIR ${FASTME_PATH}
+
+RUN ./configure --prefix=/usr/local && make install
+
 ########################### orthoFinder install & run tests #############################
+ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/archive/1.1.4.zip
+ENV ORTHOFINDER_FILE_NAME 1.1.4.zip
+ENV ORTHOFINDER_PATH /opt/OrthoFinder-1.1.4/orthofinder
 
 WORKDIR /opt
 RUN wget ${ORTHOFINDER_URL} --no-check-certificate && unzip ${ORTHOFINDER_FILE_NAME}
 ENV PATH "$PATH:${ORTHOFINDER_PATH}"
 
 WORKDIR /root
-
+RUN pwd && ls -1
 RUN orthofinder.py -f ${ORTHOFINDER_PATH}/ExampleDataset/
 
 ########################## clean source file #################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Set the base image to debian blast
 FROM simonalpha/ncbi-blast-docker
 
-LABEL version="1.1.4"
+LABEL version="1.1.8"
 
 # Set noninterative mode
 ENV DEBIAN_FRONTEND noninteractive
@@ -56,10 +56,16 @@ WORKDIR ${FASTME_PATH}
 
 RUN ./configure --prefix=/usr/local && make install
 
+################# DIAMOND install ########################
+ENV DIAMOND_URL https://github.com/bbuchfink/diamond/releases/download/v0.9.9/diamond-linux64.tar.gz
+
+WORKDIR /opt
+RUN wget ${DIAMOND_URL} --no-check-certificate -O - | tar xvzf - && mv diamond /usr/local/bin/diamond-sse2
+
 ########################### orthoFinder install & run tests #############################
-ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/archive/1.1.4.zip
-ENV ORTHOFINDER_FILE_NAME 1.1.4.zip
-ENV ORTHOFINDER_PATH /opt/OrthoFinder-1.1.4/orthofinder
+ENV ORTHOFINDER_URL https://github.com/davidemms/OrthoFinder/archive/1.1.8.zip
+ENV ORTHOFINDER_FILE_NAME 1.1.8.zip
+ENV ORTHOFINDER_PATH /opt/OrthoFinder-1.1.8/orthofinder
 
 WORKDIR /opt
 RUN wget ${ORTHOFINDER_URL} --no-check-certificate && unzip ${ORTHOFINDER_FILE_NAME}
@@ -71,7 +77,7 @@ RUN orthofinder.py -f ${ORTHOFINDER_PATH}/ExampleDataset/
 
 ########################## clean source file #################################
 
-RUN rm -r /opt/1.1.4.zip
+RUN rm -r /opt/1.1.8.zip
 
 ###############################################################
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ docker build --rm -t username/imagename .
 ### Use orthofinder in docker
 
 docker run -it --rm cmonjeau/orthofinder orthofinder.py -f fasta_directory -t number_of_processes
+
+docker run -it --rm cmonjeau/orthofinder orthofinder.py -f fasta_directory -t n_blast_processes -a n_orthofinder_threads -S diamond


### PR DESCRIPTION
- New dependencies: fastme (bin) and dlcpar (python2 package)
- Reordered some lines (variables) so it runs faster (having to reinstall scipy/numpy sucks)