### PR TITLE
Add execute permission to FastTree (otherwise not found on path)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN pip install scipy
 
 ################# Fastree install ########################
 
-RUN wget -P /usr/local/bin ${FASTTREE_URL}
+RUN wget -P /usr/local/bin ${FASTTREE_URL} && \
+  chmod a+x /usr/local/bin/FastTree
 
 ################# MCL install ########################
 


### PR DESCRIPTION
Hi Cyril,

This is a tiny bugfix to add execute permission to FastTree - otherwise it's not found on the path when attempting to run ``trees_for_orthologs.py``. 

    Test can run "mafft /input/Results_Sep23/WorkingDirectory/SimpleTest.fa" - ok
    Test can run "mafft /input/Results_Sep23/WorkingDirectory/SimpleTest.fa" - ok
    Test can run "FastTree /input/Results_Sep23/WorkingDirectory/SimpleTest.fa" - failed
    ERROR: Cannot run FastTree
    Please check FastTree is installed and that the executables are in the system path

I'm also submitting a few small changes in the README in another PR - because I slightly changed the format to include mounting the host directory I wasn't sure if you wanted to use that or not, so I figured I'd make this easy to pull without adjusting the readme. Thanks,